### PR TITLE
Upgrading IntelliJ from 2022.2.4 to 2022.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2022.2.4 to 2022.3.0
 - Upgrading IntelliJ from 2022.2 to 2022.2.4
 
 ### Deprecated

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,8 +34,8 @@ platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.chriscarini.jetbrains.loc-change-count-detector-jetbrains-plugin:0.0.5
-locPluginVersion = 0.0.5
+platformPlugins = com.chriscarini.jetbrains.loc-change-count-detector-jetbrains-plugin:0.1.0
+locPluginVersion = 0.1.0
 
 # Java language level used to compile sources and to generate the files for
 # - Java 11 is required since 2020.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Example LoC Configuration Plugin'
 # SemVer format -> https://semver.org
-pluginVersion = 0.0.3
+pluginVersion = 0.1.0
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -15,7 +15,7 @@ pluginVersion = 0.0.3
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.2.4,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2022.3,LATEST-EAP-SNAPSHOT
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `productivityFeaturesProvider` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
@@ -29,7 +29,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2022.2.4
+platformVersion = 2022.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/updatePlugins.template.xml
+++ b/updatePlugins.template.xml
@@ -16,6 +16,6 @@
             url="file:/PATH_TO_REPLACE/loc-change-count-detector-jetbrains-plugin/build/distributions/CORRECT_PLUGIN_FILENAME"
             version="LOC_VERSION_TO_REPLACE">
         <!-- The <idea-version> element (required) must match the same element in the plugin.xml file. -->
-        <idea-version since-build="221.5080" until-build="221.*"/>
+        <idea-version since-build="223.7571" until-build="223.*" />
     </plugin>
 </plugins>


### PR DESCRIPTION

# Upgrading IntelliJ from 2022.2.4 to 2022.3.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661406/IntelliJ-IDEA-2022.3-223.7571.182-build-Release-Notes

# What's New?
IntelliJ IDEA 2022.3 is now available with the following updates: 
<ul> 
 <li>New IDE UI available via settings</li> 
 <li>New Settings Sync solution</li> 
 <li>New way to work with projects in WSL2</li> 
 <li>New actions for autowiring Spring beans and generating OpenAPI schemas</li> 
 <li>Redis support</li> 
</ul> Visit our 
<a href="https://www.jetbrains.com/idea/whatsnew/">What's New page</a> to learn about all of the new features and improvements.
    