### PR TITLE
Upgrading IntelliJ from 2023.3.3 to 2023.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.3.3 to 2023.3.4
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Example LoC Configuration Plugin'
 # SemVer format -> https://semver.org
-pluginVersion = 0.4.3
+pluginVersion = 0.4.4
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -15,7 +15,7 @@ pluginVersion = 0.4.3
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.3.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.3.4,LATEST-EAP-SNAPSHOT
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `productivityFeaturesProvider` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
@@ -29,7 +29,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.3.3
+platformVersion = 2023.3.4
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.3.3 to 2023.3.4

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661858/IntelliJ-IDEA-2023.3.4-233.14475.28-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.3.4 is out with the following updates: 
<ul> 
 <li>The progress bar for building tasks in Gradle projects is once again displayed. [<a href="https://youtrack.jetbrains.com/issue/IDEA-344392/Return-progress-indicator-for-compiling-Gradle-tasks">IDEA-344392</a>]</li> 
 <li>We've addressed the issue with the <em>Settings Sync</em> functionality, and now, instead of reporting an authorization problem, the IDE prompts you to log in with your JetBrains Account. [<a href="https://youtrack.jetbrains.com/issue/IDEA-343073/Setting-Sync-sync-failed.-couldnt-get-settings-from-server-Authentication-required">IDEA-343073</a>]</li> 
 <li>The IDE now successfully adds Kubernetes сontexts from config files. [<a href="https://youtrack.jetbrains.com/issue/IDEA-341416/Kubernetes-plugin-crashes-when-trying-to-load-config">IDEA-341416</a>]</li> 
 <li>Customizing inspection severities is once again accessible in <em>Settings/Preferences | Editor | Inspections</em>. [<a href="https://youtrack.jetbrains.com/issue/IDEA-341773/Inspections-Edit-severities-no-longer-opens-the-Severities-Editor">IDEA-341773</a>]</li> 
 <li>The IDE once again properly recognizes and resolves custom DataSource configuration properties. [<a href="https://youtrack.jetbrains.com/issue/IDEA-343779/ConfigurationProperties-method-keys-with-library-return-type-not-collected">IDEA-343779</a>]</li> 
 <li>We've addressed several issues that were occurring when working with the HTTP Client. [<a href="https://youtrack.jetbrains.com/issue/IDEA-330341/">IDEA-330341</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-334527/">IDEA-334527</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-337644/">IDEA-337644</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-338836/">IDEA-338836</a>], [<a href="https://youtrack.jetbrains.com/issue/IDEA-338958/">IDEA-338958</a>]</li> 
</ul> For more details, please refer to this 
<a href="https://blog.jetbrains.com/idea/2024/02/intellij-idea-2023-3-4/">blog post</a>.
    