### PR TITLE
Upgrading IntelliJ from 2024.2 to 2024.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.1.5 to 2024.2.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,16 +5,16 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Example LoC Configuration Plugin'
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.5
+pluginVersion = 1.1.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 241
-pluginUntilBuild = 241.*
+pluginSinceBuild = 242
+pluginUntilBuild = 242.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.1.5,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.2.1,LATEST-EAP-SNAPSHOT
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `productivityFeaturesProvider` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
@@ -28,7 +28,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.1.5
+platformVersion = 2024.2.1
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.2 to 2024.2.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662153/IntelliJ-IDEA-2024.2.1-242.21829.142-build-Release-Notes

# What's New?
<p> IntelliJ IDEA 2024.2.1 is out. This release adds Java 23 support and introduces a host of noteworthy fixes and improvements: </p> 
<ul> 
 <li>The IDE no longer crashes on macOS when the terminal is open. [<a href="https://youtrack.jetbrains.com/issue/IJPL-157074">IJPL-157074</a>] </li>
 <li>The IDE no longer fails to start when non-ASCII characters are present in the installation path. [<a href="https://youtrack.jetbrains.com/issue/IJPL-156417/Cannot-start-the-IDE-due-to-Error-occurred-during-initialization-of-VM-error-when-having-non-ascii-chars-in-the-installation">IJPL-156417</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-35364/The-IDE-doesnt-start-if-an-installation-directory-contain-non-Latin-characters-that-do-not-match-to-systems-ANSI-encoding">IJPL-35364</a>] </li>
 <li>The IDE now correctly recognizes java-test-fixtures as generated test sources. [<a href="https://youtrack.jetbrains.com/issue/IDEA-353172">IDEA-353172</a>] </li>
 <li>The IDE now saves projects more quickly upon closing, resolving the issue of occasional delays. [<a href="https://youtrack.jetbrains.com/issue/IJPL-148614">IJPL-148614</a>] </li> 
</ul> 
<p> Get more details in our <a href="https://blog.jetbrains.com/idea/2024/08/intellij-idea-2024-2-1/">blog post</a>. </p>
    