### PR TITLE
Upgrading IntelliJ from 2024.2.1 to 2024.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.2.1 to 2024.2.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/example-loc-plugin-config-p
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 1.1.1
+pluginVersion = 1.1.2
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 242.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.2.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.2.2,LATEST-EAP-SNAPSHOT
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `productivityFeaturesProvider` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
@@ -37,7 +37,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.2.1
+platformVersion = 2024.2.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.2.1 to 2024.2.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662225/IntelliJ-IDEA-2024.2.2-242.22855.74-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.2.2 is out. This release brings a host of noteworthy fixes and improvements: 
<ul> 
 <li>Highlighting no longer “blinks” upon typing.</li> 
 <li>Debugging for the spring-boot:run Maven goal is once again available.</li> 
 <li>Non-Latin letters and characters are properly displayed in the Run console.</li> 
 <li>It’s again possible to save the project settings with Coverage if the Qodana plugin is enabled.</li> 
</ul> Get more details in our 
<a href="https://blog.jetbrains.com/idea/2024/09/intellij-idea-2024-2-2/">blog post</a>.
    