### PR TITLE
Upgrading IntelliJ from 2024.3.2.2 to 2024.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.2.2 to 2024.3.3
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/example-loc-plugin-config-p
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 1.2.5
+pluginVersion = 1.2.6
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.3.2.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.3.3,LATEST-EAP-SNAPSHOT
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `productivityFeaturesProvider` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
@@ -37,7 +37,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.3.2.2
+platformVersion = 2024.3.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.2.2 to 2024.3.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662361/IntelliJ-IDEA-2024.3.3-243.24978.46-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2024.3.3 is out with the following improvements:</p>
<ul>
 <li>The <em>Reload All Maven Projects</em> action now correctly syncs dependencies. [<a href="https://youtrack.jetbrains.com/issue/IDEA-358024">IDEA-358024</a>]</li>
 <li>Screen reader detection now works on the first startup on Windows. [<a href="https://youtrack.jetbrains.com/issue/IJPL-173992/Screen-reader-detection-on-the-first-start-up-stopped-working-on-Windows">IJPL-173992</a>]</li>
 <li>Custom toolbar icons for external tools are now properly displayed after an IDE restart. [<a href="https://youtrack.jetbrains.com/issue/IJPL-172075/Custom-toolbar-icons-for-External-tools-is-not-shown-after-IDE-restart">IJPL-172075</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2025/02/intellij-idea-2024-3-3/">blog post</a>.</p>
    