### PR TITLE
Upgrading IntelliJ from 2025.1.1 to 2025.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.1.1 to 2025.1.3
 - Upgrading IntelliJ from 2025.1 to 2025.1.1
 
 ### Deprecated

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/example-loc-plugin-config-p
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 2.0.0
+pluginVersion = 2.0.1
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 251.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.1.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.1.3,LATEST-EAP-SNAPSHOT
 # Exclude `NOT_DYNAMIC` Failure Level because we make use of `productivityFeaturesProvider` (in `plugin.xml`)
 # which is considered to be a non-dynamic feature.
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
@@ -37,7 +37,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.1.1
+platformVersion = 2025.1.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.1.1 to 2025.1.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662461/IntelliJ-IDEA-2025.1.3-251.26927.53-build-Release-Notes

# What's New?
<p>IntelliJ IDEA 2025.1.3 is out with the following improvements:</p>
<ul>
 <li>The IDE no longer erroneously displays &lt;no name&gt; in the <em>Test Results</em> tree in the <em>Run</em> tool window for Dart tests. [<a href="https://youtrack.jetbrains.com/issue/IDEA-328307/Dart-tests-no-name-shown-under-Test-Results">IDEA-328307</a>]</li>
 <li>The preview panel is now available for AsyncAPI 3.0 files. [<a href="https://youtrack.jetbrains.com/issue/IJPL-63246/AsyncAPI-Preview-not-available-for-version-3.0">IJPL-63246</a>]</li>
 <li>The IDE no longer truncates postCreateCommand environment variables at equals signs in the build process output. [<a href="https://youtrack.jetbrains.com/issue/IJPL-188006/PostCreateCommand-environment-variables-are-truncated-at-equals-signs">IJPL-188006</a>]</li>
</ul>
<ul>
 <li>The IDE no longer misses OS-specific plugins in Aarch64 distributions, including those required for WSL support in the Python interpreter. [<a href="https://youtrack.jetbrains.com/issue/IJPL-189778/OS-specific-plugins-could-be-missing-in-Aarch64-distributions">IJPL-189778</a>]</li>
</ul>
<p>Get more details from our <a href="https://blog.jetbrains.com/idea/2025/06/intellij-idea-2025-1-3/">blog post</a>.</p>
    